### PR TITLE
Show detailed symbol analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# smart-trader-app
+# Smart Trader App
+
+This repository contains a simple static market watch list example.
+
+The watchlist displays recommended stocks sorted by daily change from high to low.
+
+Open `watchlist.html` in a web browser to view a table of sample symbols, quotes, and daily changes. Clicking a row opens an analysis page for the selected symbol displaying its RSI and resistance, Bollinger cross, average trade volume, a Yahoo Finance recommendation, and example high and low prices from the past.

--- a/analysis.html
+++ b/analysis.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Symbol Analysis</title>
+  <style>
+    body { font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1 id="title">Symbol Analysis</h1>
+  <div id="content"></div>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const symbol = params.get('symbol') || 'Unknown';
+    document.getElementById('title').textContent = symbol + ' Analysis';
+
+    // Sample placeholder data for demonstration purposes
+    const analysisData = {
+      AAPL: {
+        rsi: 55,
+        resistance: 195,
+        bollinger: 'Crossed upper band',
+        average_trade: '1.1M',
+        recommendation: 'Buy',
+        historical_high: { price: 199.62, date: '2024-06-10' },
+        historical_low: { price: 120.13, date: '2023-10-05' }
+      },
+      GOOGL: {
+        rsi: 48,
+        resistance: 130,
+        bollinger: 'Near lower band',
+        average_trade: '800K',
+        recommendation: 'Hold',
+        historical_high: { price: 150.24, date: '2024-04-12' },
+        historical_low: { price: 88.34, date: '2023-09-19' }
+      },
+      MSFT: {
+        rsi: 60,
+        resistance: 340,
+        bollinger: 'Above middle band',
+        average_trade: '950K',
+        recommendation: 'Buy',
+        historical_high: { price: 345.76, date: '2024-05-17' },
+        historical_low: { price: 250.15, date: '2023-10-30' }
+      },
+      TSLA: {
+        rsi: 42,
+        resistance: 275,
+        bollinger: 'Below lower band',
+        average_trade: '2M',
+        recommendation: 'Sell',
+        historical_high: { price: 409.97, date: '2022-11-05' },
+        historical_low: { price: 150.22, date: '2023-12-20' }
+      }
+    };
+
+    const data = analysisData[symbol] || {};
+
+    const content = document.getElementById('content');
+    content.innerHTML = `
+      <p><strong>RSI - Resistance:</strong> ${data.rsi !== undefined ? `${data.rsi} - ${data.resistance}` : 'N/A'}</p>
+      <p><strong>Bollinger cross:</strong> ${data.bollinger || 'N/A'}</p>
+      <p><strong>Average trade:</strong> ${data.average_trade || 'N/A'}</p>
+      <p><strong>Recommendation from Yahoo Finance:</strong> ${data.recommendation || 'N/A'}</p>
+      <p><strong>Similar past prices:</strong></p>
+      <ul>
+        <li><strong>Highest:</strong> ${data.historical_high ? `${data.historical_high.price} (${data.historical_high.date})` : 'N/A'}</li>
+        <li><strong>Lowest:</strong> ${data.historical_low ? `${data.historical_low.price} (${data.historical_low.date})` : 'N/A'}</li>
+      </ul>
+    `;
+  </script>
+</body>
+</html>

--- a/watchlist.html
+++ b/watchlist.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>מניות מומלצות</title>
+  <style>
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 8px; }
+    .positive { color: green; }
+    .negative { color: red; }
+    tr { cursor: pointer; }
+  </style>
+</head>
+<body>
+  <h1>מניות מומלצות</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Logo</th>
+        <th>Symbol</th>
+        <th>Quote</th>
+        <th>Daily Change</th>
+      </tr>
+    </thead>
+    <tbody id="watchlist-body">
+    </tbody>
+  </table>
+  <script>
+    const watchlist = [
+      { symbol: 'AAPL', logo: 'https://logo.clearbit.com/apple.com', quote: 190.69, daily_change: 1.05 },
+      { symbol: 'GOOGL', logo: 'https://logo.clearbit.com/google.com', quote: 124.30, daily_change: -0.95 },
+      { symbol: 'MSFT', logo: 'https://logo.clearbit.com/microsoft.com', quote: 330.12, daily_change: 0.50 },
+      { symbol: 'TSLA', logo: 'https://logo.clearbit.com/tesla.com', quote: 265.45, daily_change: -2.30 }
+    ];
+      watchlist.sort((a, b) => b.daily_change - a.daily_change);
+
+    const tbody = document.getElementById('watchlist-body');
+    watchlist.forEach(item => {
+      const row = document.createElement('tr');
+      row.addEventListener('click', () => {
+        window.location.href = 'analysis.html?symbol=' + encodeURIComponent(item.symbol);
+      });
+
+      const logoCell = document.createElement('td');
+      const img = document.createElement('img');
+      img.src = item.logo;
+      img.alt = item.symbol + ' logo';
+      img.width = 20;
+      img.height = 20;
+      logoCell.appendChild(img);
+      row.appendChild(logoCell);
+
+      const symbolCell = document.createElement('td');
+      symbolCell.textContent = item.symbol;
+      row.appendChild(symbolCell);
+
+      const quoteCell = document.createElement('td');
+      quoteCell.textContent = item.quote.toFixed(2);
+      row.appendChild(quoteCell);
+
+      const changeCell = document.createElement('td');
+      changeCell.textContent = item.daily_change.toFixed(2) + '%';
+      changeCell.className = item.daily_change >= 0 ? 'positive' : 'negative';
+      row.appendChild(changeCell);
+
+      tbody.appendChild(row);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add details section in analysis.html with sample data for each symbol
- document that the analysis page now displays RSI, Bollinger cross, average trade, Yahoo Finance recommendation and past prices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b4cd3441c83299a7d6d0b716acb94